### PR TITLE
On Mac, allow dropping some files on the app's dock icon. …

### DIFF
--- a/embroidermodder2/Info.plist
+++ b/embroidermodder2/Info.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>CFBundleIconFile</key>
+	<string>embroidermodder2.icns</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleGetInfoString</key>
+	<string>Version 0.8</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>DST</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>DST</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>PES</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>PES</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>CSV</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>CSV</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>DXF</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>DXF</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>embroidermodder2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.turbozen.embroidermodder2</string>
+</dict>
+</plist>

--- a/embroidermodder2/application.cpp
+++ b/embroidermodder2/application.cpp
@@ -1,0 +1,19 @@
+#include "application.h"
+#include "mainwindow.h"
+
+Application::Application(int argc, char **argv) : QApplication(argc, argv), _mainWin(NULL) {
+}
+
+bool Application::event(QEvent *event) {
+    switch (event->type()) {
+    case QEvent::FileOpen:
+        if (_mainWin) {
+            _mainWin->openFilesSelected(QStringList(static_cast<QFileOpenEvent *>(event)->file()));
+            return true;
+        }
+        // Fall through
+    default:
+        return QApplication::event(event);
+    }
+}
+

--- a/embroidermodder2/application.cpp
+++ b/embroidermodder2/application.cpp
@@ -1,10 +1,12 @@
 #include "application.h"
 #include "mainwindow.h"
 
-Application::Application(int argc, char **argv) : QApplication(argc, argv), _mainWin(NULL) {
+Application::Application(int argc, char **argv) : QApplication(argc, argv), _mainWin(NULL)
+{
 }
 
-bool Application::event(QEvent *event) {
+bool Application::event(QEvent *event)
+{
     switch (event->type()) {
     case QEvent::FileOpen:
         if (_mainWin) {

--- a/embroidermodder2/application.h
+++ b/embroidermodder2/application.h
@@ -1,0 +1,21 @@
+#ifndef APPLICATION_H
+#define APPLICATION_H
+
+#include <QApplication>
+
+class MainWindow;
+
+// On Mac, if the user drops a file on the app's Dock icon, or uses Open As, then this is how the app actually opens the file.
+class Application : public QApplication
+{
+    Q_OBJECT
+public:
+    Application(int argc, char **argv);
+    void setMainWin(MainWindow* mainWin) { _mainWin = mainWin; }
+protected:
+    virtual bool event(QEvent *e);
+private:
+    MainWindow* _mainWin;
+};
+
+#endif // APPLICATION_H

--- a/embroidermodder2/embroidermodder2.pro
+++ b/embroidermodder2/embroidermodder2.pro
@@ -101,6 +101,7 @@ object-polygon.cpp \
 object-polyline.cpp \
 object-rect.cpp \
 object-textsingle.cpp \
+    application.cpp
 
 HEADERS += \
 mainwindow.h \
@@ -135,6 +136,7 @@ object-polygon.h \
 object-polyline.h \
 object-rect.h \
 object-textsingle.h \
+    application.h
 
 #SCRIPTING
 SOURCES += \
@@ -267,6 +269,8 @@ macx {
                          bundletrans \
                          bundletips \
 
+    QMAKE_INFO_PLIST = Info.plist
+    OTHER_FILES += Info.plist
 }
 
 #TODO: Windows: make install
@@ -359,3 +363,6 @@ QMAKE_EXTRA_TARGETS += installer
 #QMAKE_CXXFLAGS_WARN_ON += -Wno-unknown-pragmas
 
 QMAKE_DISTCLEAN += object_script.*
+
+DISTFILES += \
+    Info.plist

--- a/embroidermodder2/main.cpp
+++ b/embroidermodder2/main.cpp
@@ -1,5 +1,5 @@
+#include "application.h"
 #include "mainwindow.h"
-#include <QApplication>
 
 const char* _appName_ = "Embroidermodder";
 const char* _appVer_  = "v2.0 alpha";
@@ -36,7 +36,7 @@ static void version()
 
 int main(int argc, char* argv[])
 {
-    QApplication app(argc, argv);
+    Application app(argc, argv);
     app.setApplicationName(_appName_);
     app.setApplicationVersion(_appVer_);
 
@@ -61,6 +61,7 @@ int main(int argc, char* argv[])
         return 1;
 
     MainWindow* mainWin = new MainWindow();
+    app.setMainWin(mainWin);
 
     QObject::connect(&app, SIGNAL(lastWindowClosed()), mainWin, SLOT(quit()));
 

--- a/embroidermodder2/mainwindow-settings.cpp
+++ b/embroidermodder2/mainwindow-settings.cpp
@@ -2,13 +2,36 @@
 #include "settings-dialog.h"
 
 #include <QDebug>
+#include <QtGlobal>
 #include <QSettings>
+
+namespace {
+
+// Note: on Unix we include the trailing separator. For Windows compatibility we omit it.
+QString SettingsDir() {
+#if defined(Q_OS_UNIX) || defined(Q_OS_MAC)
+  QString homePath = QDir::homePath();
+  return homePath + "/.embroidermodder2/";
+#else
+  return "";
+#endif
+}
+
+QString SettingsPath() {
+  QString settingsPath = SettingsDir() + "settings.ini";
+  return settingsPath;
+}
+
+}
 
 void MainWindow::readSettings()
 {
     qDebug("Reading Settings...");
+    // This file needs to be read from the users home directory to ensure it is writable
+    QString settingsPath = SettingsPath();
+    QString settingsDir = SettingsDir();
     QString appDir = qApp->applicationDirPath();
-    QSettings settings(appDir + "/settings.ini", QSettings::IniFormat); //TODO: This file needs to be read from the users home directory to ensure it is writable
+    QSettings settings(settingsPath, QSettings::IniFormat);
     QPoint pos = settings.value("Window/Position", QPoint(0, 0)).toPoint();
     QSize size = settings.value("Window/Size", QSize(800, 600)).toSize();
 
@@ -60,7 +83,7 @@ void MainWindow::readSettings()
     settings_prompt_font_size               = settings.value("Prompt/FontSize",                                  12).toInt();
     settings_prompt_save_history            = settings.value("Prompt/SaveHistory",                             true).toBool();
     settings_prompt_save_history_as_html    = settings.value("Prompt/SaveHistoryAsHtml",                      false).toBool();
-    settings_prompt_save_history_filename   = settings.value("Prompt/SaveHistoryFilename",    appDir + "prompt.log").toString(); //TODO: This file needs to be read from the users home directory to ensure it is writable
+    settings_prompt_save_history_filename   = settings.value("Prompt/SaveHistoryFilename",    settingsDir + "prompt.log").toString();
     //OpenSave
     settings_opensave_custom_filter         = settings.value("OpenSave/CustomFilter",                   "supported").toString();
     settings_opensave_open_format           = settings.value("OpenSave/OpenFormat",                           "*.*").toString();
@@ -146,8 +169,9 @@ void MainWindow::readSettings()
 void MainWindow::writeSettings()
 {
     qDebug("Writing Settings...");
-    QString appDir = qApp->applicationDirPath();
-    QSettings settings(appDir + "/settings.ini", QSettings::IniFormat); //TODO: This file needs to be read from the users home directory to ensure it is writable
+    QString settingsPath = SettingsPath();
+    // This file needs to be read from the users home directory to ensure it is writable
+    QSettings settings(settingsPath, QSettings::IniFormat);
     QString tmp;
     settings.setValue("Window/Position", pos());
     settings.setValue("Window/Size", size());

--- a/embroidermodder2/mainwindow-settings.cpp
+++ b/embroidermodder2/mainwindow-settings.cpp
@@ -8,7 +8,8 @@
 namespace {
 
 // Note: on Unix we include the trailing separator. For Windows compatibility we omit it.
-QString SettingsDir() {
+QString SettingsDir()
+{
 #if defined(Q_OS_UNIX) || defined(Q_OS_MAC)
   QString homePath = QDir::homePath();
   return homePath + "/.embroidermodder2/";
@@ -17,12 +18,13 @@ QString SettingsDir() {
 #endif
 }
 
-QString SettingsPath() {
+QString SettingsPath()
+{
   QString settingsPath = SettingsDir() + "settings.ini";
   return settingsPath;
 }
 
-}
+} // end anonymous namespace
 
 void MainWindow::readSettings()
 {


### PR DESCRIPTION
Store the settings.ini and prompt.log in ~/.embroidermodder/ as is the convention for Unix programs running on Mac (App directories are expected to be read-only). The change should not affect other platforms. https://github.com/Embroidermodder/Embroidermodder/commit/5fd354d49baa8e15ad36ecf5f159b3089ee0be2a - change 5fd354d is the same but with a few newlines added to comply with the coding style guide.