### PR TITLE
Add qt5-script package to dependencies list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Optionally, you may want to add:
 Ubuntu repository packages:
 The Qt, KDE and Valgrind build dependencies can be installed easily by opening a terminal and issuing this command:
 ```
-sudo apt-get install git build-essential qt4-dev-tools libqt4-opengl-dev kdelibs5-dev valgrind
+sudo apt-get install git build-essential qt4-dev-tools libqt4-opengl-dev kdelibs5-dev valgrind qtscript5-dev
 ```
 
 Fedora repository packages:
 The Qt, KDE and Valgrind build dependencies can be installed easily by opening a terminal and issuing this command:
 ```
-sudo yum install git gdb gcc-c++ qt-devel kdelibs-devel valgrind
+sudo yum install git gdb gcc-c++ qt-devel kdelibs-devel valgrind qt5-qtscript-devel
 ```
 Building
 --------


### PR DESCRIPTION
As of today attempting to build Embroidermodder on Debian Stretch without `qtscript5-dev` results in following:
```
Info: creating stash file /home/strix/Embroidermodder/embroidermodder2/.qmake.stash
Project MESSAGE: debug build
Project ERROR: Unknown module(s) in QT: script scripttools
```
After installation of `qtscript5-dev` building is successful. 
Please note that this is tested on Debian Stretch only. Update for Fedora is provided just by finding `qt5-qtscript-devel` in their package repo: https://apps.fedoraproject.org/packages/qt5-qtscript-devel, so it probably needs more testing.