### PR TITLE
Fix endless loop and segmentation fault in ofm reader

### DIFF
--- a/libembroidery/format-ofm.c
+++ b/libembroidery/format-ofm.c
@@ -221,7 +221,7 @@ int readOfm(EmbPattern* pattern, const char* fileName)
     key = ofmReadClass(file);
     while(1)
     {
-        if(key == 0xFEFF)
+        if(key == 0xFEFF || embFile_eof(file))
         {
             break;
         }
@@ -244,7 +244,7 @@ int readOfm(EmbPattern* pattern, const char* fileName)
     embFile_close(file);
 
     /* Check for an END stitch and add one if it is not present */
-    if(pattern->lastStitch->stitch.flags != END)
+    if(!pattern ->lastStitch || pattern->lastStitch->stitch.flags != END)
         embPattern_addStitchRel(pattern, 0, 0, END, 1);
 
     embPattern_flip(pattern, 1, 1);


### PR DESCRIPTION
I tried to debug issue #103 and found two problems:
First, there is a loop which waits for some magic number to occur in the ofm file, if it never occurs it will loop forever. I added a check for eof.
Second, if the file is not properly read there is a segmentation fault when accessing pattern->lastStitch->stitch.flags. I added a check to fix that.
Sadly, it doesn't fix issue #103, the problem is with the reader which I can not debug because I don't know anything about the file format.