### PR TITLE
fix handling of long filenames in PEC/PES

### DIFF
--- a/libembroidery/format-pec.c
+++ b/libembroidery/format-pec.c
@@ -278,11 +278,14 @@ void writePecStitches(EmbPattern* pattern, EmbFile* file, const char* fileName)
     }
     binaryWriteBytes(file, "LA:", 3);
     flen = (int)(dotPos - start);
-
-    while(start < dotPos)
+    if (flen > 16)
     {
-        binaryWriteByte(file, (unsigned char)*start);
-        start++;
+        flen = 16;
+    }
+
+    for (i = 0; i < flen; i++)
+    {
+        binaryWriteByte(file, (unsigned char)*(start + i));
     }
     for(i = 0; i < (int)(16-flen); i++)
     {


### PR DESCRIPTION
This change limits the 'LA:' field to 16 bytes even when the file name is longer, to avoid corrupting a PEC/PES file.

fixes Embroidermodder/Embroidermodder#107