### PR TITLE
Fix various typos

### DIFF
--- a/CODE-STANDARDS.txt
+++ b/CODE-STANDARDS.txt
@@ -56,7 +56,7 @@ When writing code, sometimes there are items that we know can be improved,
 incomplete or need special clarification. In these cases, use the types of
 comments shown below. They are pretty standard and are highlighted by many editors to
 make reviewing code easier. We also use shell scripts to parse the code to find
-all of these occurances so someone wanting to go on a bug hunt will be able to
+all of these occurrences so someone wanting to go on a bug hunt will be able to
 easily see which areas of the code need more love.
 
 //C++ Style Comments

--- a/CREDITS.ini
+++ b/CREDITS.ini
@@ -5,9 +5,9 @@
 ; number. Fill it in with your information and submit it to us.
 ;
 ; Here is a summary of the values used:
-; Name - The full name of the contributer starting with first name.
-; GitHub - The GitHub account name of the contributer.
-; CoreDeveloper - This is reserved for long term contributers.
+; Name - The full name of the contributor starting with first name.
+; GitHub - The GitHub account name of the contributor.
+; CoreDeveloper - This is reserved for long term contributors.
 ; Documentation - If you have contributed changes to README files or help files, set this to true.
 ; Artwork - If you have contributed artwork or related changes, set this to true
 ; BugFixes - If you have contributed bug fixes or added new features, set this to true.

--- a/ZLIB-LICENSE.txt
+++ b/ZLIB-LICENSE.txt
@@ -3,7 +3,7 @@ Unless explicitly noted otherwise here, the source code is zlib licensed as foll
 ***************************************************************
 * Embroidermodder 2, libembroidery and all other related code *
 ***************************************************************
-Copyright (c) 2011-2014 Embroidermodder, Jonathan Greig, Josh Varga and all other contributers
+Copyright (c) 2011-2014 Embroidermodder, Jonathan Greig, Josh Varga and all other contributors
 
 This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
 

--- a/embroidermodder2/mainwindow-actions.cpp
+++ b/embroidermodder2/mainwindow-actions.cpp
@@ -101,7 +101,7 @@ QAction *MainWindow::createAction(const QString icon, const QString toolTip, con
     ACTION->setStatusTip(statusTip);
     ACTION->setObjectName(icon);
     // TODO: Set What's This Context Help to statusTip for now so there is some infos there.
-    // Make custom whats this context help popup with more descriptive help than just
+    // Make custom What's This Context Help popup with more descriptive help than just
     // the status bar/tip one liner(short but not real long) with a hyperlink in the custom popup
     // at the bottom to open full help file description. Ex: like wxPython AGW's SuperToolTip.
     ACTION->setWhatsThis(statusTip);

--- a/embroidermodder2/mainwindow-commands.cpp
+++ b/embroidermodder2/mainwindow-commands.cpp
@@ -759,10 +759,10 @@ void MainWindow::colorSelectorIndexChanged(int index)
         //TODO: Handle ByLayer and ByBlock and Other...
         newColor = comboBox->itemData(index).toUInt(&ok);
         if(!ok)
-            QMessageBox::warning(this, tr("Color Selector Conversion Error"), tr("<b>An error has occured while changing colors.</b>"));
+            QMessageBox::warning(this, tr("Color Selector Conversion Error"), tr("<b>An error has occurred while changing colors.</b>"));
     }
     else
-        QMessageBox::warning(this, tr("Color Selector Pointer Error"), tr("<b>An error has occured while changing colors.</b>"));
+        QMessageBox::warning(this, tr("Color Selector Pointer Error"), tr("<b>An error has occurred while changing colors.</b>"));
 
     MdiWindow* mdiWin = qobject_cast<MdiWindow*>(mdiArea->activeSubWindow());
     if(mdiWin) { mdiWin->currentColorChanged(newColor); }

--- a/embroidermodder2/object-arc.cpp
+++ b/embroidermodder2/object-arc.cpp
@@ -263,7 +263,7 @@ qreal ArcObject::objectIncludedAngle() const
 {
     qreal chord = objectChord();
     qreal rad = objectRadius();
-    if(chord <= 0 || rad <= 0) return 0; //Prevents division by zero and non-existant circles
+    if(chord <= 0 || rad <= 0) return 0; //Prevents division by zero and non-existent circles
 
     //NOTE: Due to floating point rounding errors, we need to clamp the quotient so it is in the range [-1, 1]
     //      If the quotient is out of that range, then the result of asin() will be NaN.

--- a/valgrind-supp/valgrind-create-suppressions.sh
+++ b/valgrind-supp/valgrind-create-suppressions.sh
@@ -18,7 +18,7 @@
 # The checksum is used as an index in a different array. If an item with that index already exists the suppression must be a duplicate and is discarded.
  
 BEGIN { suppression=0; md5sum = "md5sum" }
-  # If the line begins with '{', it's the start of a supression; so set the var and initialise things
+  # If the line begins with '{', it's the start of a suppression; so set the var and initialise things
   /^{/  {
            suppression=1;  i=0; next 
         }
@@ -31,7 +31,7 @@ BEGIN { suppression=0; md5sum = "md5sum" }
              delete supparray     # We don't want subsequent suppressions to append to it!
            }
      }
-  # Otherwise, it's a normal line. If we're inside a supression, store it, and pipe it to md5sum. Otherwise it's cruft, so ignore it
+  # Otherwise, it's a normal line. If we're inside a suppression, store it, and pipe it to md5sum. Otherwise it's cruft, so ignore it
      { if (suppression)
          { 
             supparray[++i] = $0


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts -L asender,ba,destry,enpoint,oll,rady,thisy`